### PR TITLE
fix: Command: Prevent args from clobbering env

### DIFF
--- a/src/cmdlib/__init__.py
+++ b/src/cmdlib/__init__.py
@@ -5,7 +5,7 @@ import os
 import shlex
 import signal
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from textwrap import indent
 from typing import TYPE_CHECKING, Any, Dict, List, NoReturn, Optional, Union
 
@@ -85,7 +85,7 @@ class Command:
         new_args = self.args[:]
         new_args.extend(args)
         new_args.extend(_item_as_option(k, v) for k, v in kw.items())
-        return Command(args=new_args, cwd=self.cwd)
+        return replace(self, args=new_args)
 
     def __str__(self) -> str:
         return " ".join(map(shlex.quote, [os.fspath(arg) for arg in self.args]))
@@ -95,7 +95,7 @@ class Command:
         return self
 
     def env(self, **env: str) -> Command:
-        return type(self)(args=self.args, cwd=self.cwd, _env=dict(self._env, **env))
+        return replace(self, _env=dict(self._env, **env))
 
     def exec(self) -> NoReturn:
         # Restore signals that the Python interpreter has called SIG_IGN on to SIG_DFL.

--- a/tests/test_cmdlib.py
+++ b/tests/test_cmdlib.py
@@ -46,6 +46,32 @@ def test_env() -> None:
     assert env["VAR2"] == "VALUE_2"
 
 
+def test_env_args() -> None:
+    script = "\n".join(["import json, os", "print(json.dumps(dict(os.environ)))"])
+    cmd = Cmd("python")
+
+    # Modify environment.
+    cmd = cmd.env(VAR1="VALUE_1")
+
+    # Add args.
+    cmd_args = cmd("-c", script)
+    env = cmd_args.json()
+    assert env["VAR1"] == "VALUE_1"
+
+
+def test_env_cwd() -> None:
+    script = "\n".join(["import json, os", "print(json.dumps(dict(os.environ)))"])
+    cmd = Cmd("python")("-c", script)
+
+    # Modify environment.
+    cmd = cmd.env(VAR1="VALUE_1")
+
+    # Set cwd.
+    cmd_cwd = cmd.current_dir(Path("/"))
+    env = cmd_cwd.json()
+    assert env["VAR1"] == "VALUE_1"
+
+
 def test_env_does_not_mutate() -> None:
     script = "\n".join(["import json, os", "print(json.dumps(dict(os.environ)))"])
     cmd = Cmd("python")("-c", script)


### PR DESCRIPTION
Setting command arguments clears any previous environment
customization.

Use `dataclasses.replace()` to ensure that `Command.__call__` only
modifies commmand arguments (other attributes are preserved).
