### PR TITLE
fix: Prevent Command.current_dir() from mutating the Command instance

### DIFF
--- a/src/cmdlib/__init__.py
+++ b/src/cmdlib/__init__.py
@@ -91,8 +91,7 @@ class Command:
         return " ".join(map(shlex.quote, [os.fspath(arg) for arg in self.args]))
 
     def current_dir(self, path: Optional[PathLike]) -> Command:
-        self.cwd = path
-        return self
+        return replace(self, cwd=path)
 
     def env(self, **env: str) -> Command:
         return replace(self, _env=dict(self._env, **env))

--- a/tests/test_cmdlib.py
+++ b/tests/test_cmdlib.py
@@ -27,6 +27,15 @@ def test_current_dir(tmp_path: Path) -> None:
     assert cwd == os.getcwd()
 
 
+def test_current_dir_does_not_mutate(tmp_path: Path) -> None:
+    cmd = Cmd("pwd")
+    cmd_tmp = cmd.current_dir(tmp_path)
+
+    # Setting current_dir in `cmd_tmp` should not affect `cmd`.
+    assert cmd.output().rstrip() == os.getcwd()
+    assert Path(cmd_tmp.output().rstrip()) == tmp_path
+
+
 def test_env() -> None:
     script = "\n".join(["import json, os", "print(json.dumps(dict(os.environ)))"])
     cmd = Cmd("python")("-c", script)


### PR DESCRIPTION
`Command.current_dir()` was modifying the `Command` instance in-place.

Return a new updated instance, instead, which is consistent with the
other methods (`Command.__call__()` and `Command.env()`.
